### PR TITLE
CRS-2222 Push operator image to private docker repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,5 @@
 name: build
-on: 
-  push:
-    branches:
-      - 'master'
+on:
   pull_request:
     branches:
       - 'master'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,4 +26,3 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_REPO: hellofresh/kubeflare-manager

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,14 +15,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      - name: Login to Docker Hub
-        uses: azure/docker-login@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,15 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: Login to Docker Hub
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+          DOCKER_REPO: hellofresh/kubeflare-manager

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: release
 
 on:
   push:
-    branches:
-      - 'master'
+    tags:
+      - '*'
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: release
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - 'master'
 
 jobs:
   goreleaser:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,6 @@ archives:
 dockers:
   - dockerfile: ./deploy/Dockerfile.manager
     image_templates:
-      - "replicated/kubeflare-manager:{{.Version}}"
+      - "{{.Env.DOCKER_REPO}}:{{.Version}}"
     binaries:
       - manager

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,21 +20,6 @@ builds:
     flags: -tags netgo -installsuffix netgo
     binary: kubeflare
     hooks: {}
-archives:
-  - id: kubeflare
-    builds:
-      - kubeflare
-    format: tar.gz
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    files:
-      - licence*
-      - LICENCE*
-      - license*
-      - LICENSE*
-      - readme*
-      - README*
-      - changelog*
-      - CHANGELOG*
 dockers:
   - dockerfile: ./deploy/Dockerfile.manager
     image_templates:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 project_name: kubeflare
 release:
   github:
-    owner: replicatedhq
+    owner: hellofresh
     name: kubeflare
 builds:
   - id: kubeflare
@@ -23,4 +23,4 @@ builds:
 dockers:
   - dockerfile: ./deploy/Dockerfile.manager
     image_templates:
-      - "{{.Env.DOCKER_REPO}}:{{.Version}}"
+      - "hellofresh/kubeflare-manager:{{.Version}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,5 +39,3 @@ dockers:
   - dockerfile: ./deploy/Dockerfile.manager
     image_templates:
       - "{{.Env.DOCKER_REPO}}:{{.Version}}"
-    binaries:
-      - manager


### PR DESCRIPTION
Update the release workflow to push to private docker repo

[Dockerhub repo](https://hub.docker.com/r/hellofresh/kubeflare-manager/tags)
[Github Release](https://github.com/hellofresh/kubeflare/releases/tag/v0.3.0-alpha.3)